### PR TITLE
feature/support-zero-prefix-and-is-decimal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,10 +46,9 @@ Unit Tests
 .. code:: sh
 
      ✘ jay@ThinkPad  ~/pii_crypt   master ±  coverage run --source=. -m unittest
-
-    ........
+    ..........
     ----------------------------------------------------------------------
-    Ran 8 tests in 0.036s
+    Ran 10 tests in 0.027s
 
     OK
 
@@ -64,11 +63,11 @@ Code Coverage
     ------------------------------------------------
     pii_crypt/__init__.py            1      0   100%
     pii_crypt/country_codes.py       1      0   100%
-    pii_crypt/pii_crypt.py          36      0   100%
+    pii_crypt/pii_crypt.py          37      0   100%
     test/__init__.py                 0      0   100%
-    test/test_pii_crypt.py          96      0   100%
+    test/test_pii_crypt.py         118      0   100%
     ------------------------------------------------
-    TOTAL                          134      0   100%
+    TOTAL                          157      0   100%
 
 License
 -------

--- a/pii_crypt/pii_crypt.py
+++ b/pii_crypt/pii_crypt.py
@@ -36,16 +36,17 @@ class PIICrypt:
     def anonymize_phone_number(self, phone_number):
         prefix = None
 
+        if phone_number.startswith('0'):
+            prefix = '0'
+            phone_number = phone_number[1:]
+
         if phone_number.endswith('.0'):
             phone_number = '{}'.format(int(float(phone_number)))
 
         if phone_number.startswith('+'):
             phone_number = phone_number[1:]
 
-        if phone_number.startswith('0'):
-            prefix = '0'
-            phone_number = phone_number[1:]
-        else:
+        if prefix is None:
             iterations = [1, 2, 3, 4]
 
             for iteration in iterations:

--- a/test/test_pii_crypt.py
+++ b/test/test_pii_crypt.py
@@ -122,6 +122,33 @@ class TestPIISecurity(unittest.TestCase):
                 result[1]),
             expected_raw_number)
 
+    def test_128bit_mobile_number_with_zero_prefix_and_is_decimal_should_pass(
+            self):
+
+        test_mobile_number = '09171230000.0'
+
+        expected_code = 'IF6DEdUrLRl+lXJpHu3sSg=='
+        expected_encrypted_number = 'K/uURi3ZioVMuHnWXgNFgA=='
+        expected_raw_code = '0'
+        expected_raw_number = '9171230000'
+
+        # encrypt
+        result = self.pg128bit.anonymize_phone_number(
+            test_mobile_number)
+
+        self.assertEqual(result[0], expected_code)
+        self.assertEqual(result[1], expected_encrypted_number)
+
+        # decrypt
+        self.assertEqual(
+            self.pg128bit.decrypt(
+                result[0]),
+            expected_raw_code)
+        self.assertEqual(
+            self.pg128bit.decrypt(
+                result[1]),
+            expected_raw_number)
+
     def test_256bit_mobile_number_with_prefix_should_pass(self):
 
         test_mobile_number = '+639171230000'
@@ -205,6 +232,33 @@ class TestPIISecurity(unittest.TestCase):
             self):
 
         test_mobile_number = '09171230000'
+
+        expected_code = 'ctz5MT3fQEdKi8UDp6RJkA=='
+        expected_encrypted_number = 'mZ/lGTxiyVRjAv1pjHHSjw=='
+        expected_raw_code = '0'
+        expected_raw_number = '9171230000'
+
+        # encrypt
+        result = self.pg256bit.anonymize_phone_number(
+            test_mobile_number)
+
+        self.assertEqual(result[0], expected_code)
+        self.assertEqual(result[1], expected_encrypted_number)
+
+        # decrypt
+        self.assertEqual(
+            self.pg256bit.decrypt(
+                result[0]),
+            expected_raw_code)
+        self.assertEqual(
+            self.pg256bit.decrypt(
+                result[1]),
+            expected_raw_number)
+
+    def test_256bit_mobile_number_with_zero_prefix_and_is_decimal_should_pass(
+            self):
+
+        test_mobile_number = '09171230000.0'
 
         expected_code = 'ctz5MT3fQEdKi8UDp6RJkA=='
         expected_encrypted_number = 'mZ/lGTxiyVRjAv1pjHHSjw=='


### PR DESCRIPTION
Support edge case where phone number contains '0' prefix, '.0' suffix.